### PR TITLE
Fixed null pointer exception when all tokens are already cached.

### DIFF
--- a/WikiClientLibrary/Site.cs
+++ b/WikiClientLibrary/Site.cs
@@ -497,18 +497,18 @@ namespace WikiClientLibrary
                 {
                     fetchTokensAsyncCoreSemaphore.Release();
                 }
-            }
-            lock (_TokensCache)
-            {
-                foreach (var key in pendingtokens)
+                lock (_TokensCache)
                 {
-                    if (_TokensCache.TryGetValue(key, out var value))
+                    foreach (var key in pendingtokens)
                     {
-                        result[key] = value;
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException("Unrecognized token: " + key + ".");
+                        if (_TokensCache.TryGetValue(key, out var value))
+                        {
+                            result[key] = value;
+                        }
+                        else
+                        {
+                            throw new InvalidOperationException("Unrecognized token: " + key + ".");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Picked this up while working on a console app that had to upload numerous images. Tracked it down to a null pointer exception that only occurs when all the tokens are cached.

Pull request fixes this by shifting the code block in question into the if statement just before, which provides the necessary protection.