### PR TITLE
Check for all values representing infinity

### DIFF
--- a/UnitTestProject1/Tests/InfrastructureTests.cs
+++ b/UnitTestProject1/Tests/InfrastructureTests.cs
@@ -40,8 +40,12 @@ namespace WikiClientLibrary.Tests.UnitTestProject1.Tests
                 DeserializeWith<DateTime>("\"2008-08-23T18:05:46Z\"", serializer));
             Assert.Equal(new DateTimeOffset(2008, 08, 23, 18, 05, 46, TimeSpan.Zero),
                 DeserializeWith<DateTimeOffset>("\"2008-08-23T18:05:46Z\"", serializer));
-            Assert.Equal(DateTime.MaxValue, DeserializeWith<DateTime>("\"infinity\"", serializer));
-            Assert.Equal(DateTimeOffset.MaxValue, DeserializeWith<DateTimeOffset>("\"infinity\"", serializer));
+            string[] infinityValues = { "infinite", "indefinite", "infinity", "never" };
+            foreach (var iTest in infinityValues)
+            {
+                Assert.Equal(DateTime.MaxValue, DeserializeWith<DateTime>($"\"{iTest}\"", serializer));
+                Assert.Equal(DateTimeOffset.MaxValue, DeserializeWith<DateTimeOffset>($"\"{iTest}\"", serializer));
+            }
         }
 
         [Fact]

--- a/WikiClientLibrary/Infrastructures/Json.cs
+++ b/WikiClientLibrary/Infrastructures/Json.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -121,9 +122,11 @@ namespace WikiClientLibrary.Infrastructures
             if (reader.TokenType == JsonToken.String)
             {
                 var expr = (string)reader.Value;
+                // See includes/GlobalFunctions.php in mediawiki/core
+                string[] infinityValues = { "infinite", "indefinite", "infinity", "never" };
                 if (objectType == typeof(DateTimeOffset))
                 {
-                    if (string.Equals(expr, "infinity", StringComparison.OrdinalIgnoreCase))
+                    if (infinityValues.Contains(expr.ToLower()))
                         return DateTimeOffset.MaxValue;
                     // quote Timestamps are always output in ISO 8601 format. endquote
                     if (DateTimeOffset.TryParseExact(expr, "yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture,
@@ -134,7 +137,7 @@ namespace WikiClientLibrary.Infrastructures
                 }
                 if (objectType == typeof(DateTime))
                 {
-                    if (string.Equals(expr, "infinity", StringComparison.OrdinalIgnoreCase))
+                    if (infinityValues.Contains(expr.ToLower()))
                         return DateTime.MaxValue;
                     if (DateTime.TryParseExact(expr, "yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture,
                         DateTimeStyles.RoundtripKind, out var result))

--- a/WikiClientLibrary/Infrastructures/Json.cs
+++ b/WikiClientLibrary/Infrastructures/Json.cs
@@ -93,6 +93,9 @@ namespace WikiClientLibrary.Infrastructures
     /// </remarks>
     public class WikiDateTimeJsonConverter : JsonConverter
     {
+        // See includes/GlobalFunctions.php in mediawiki/core
+        private static readonly string[] infinityValues = { "infinite", "indefinite", "infinity", "never" };
+
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -122,11 +125,9 @@ namespace WikiClientLibrary.Infrastructures
             if (reader.TokenType == JsonToken.String)
             {
                 var expr = (string)reader.Value;
-                // See includes/GlobalFunctions.php in mediawiki/core
-                string[] infinityValues = { "infinite", "indefinite", "infinity", "never" };
                 if (objectType == typeof(DateTimeOffset))
                 {
-                    if (infinityValues.Contains(expr.ToLower()))
+                    if (infinityValues.Contains(expr.ToLowerInvariant()))
                         return DateTimeOffset.MaxValue;
                     // quote Timestamps are always output in ISO 8601 format. endquote
                     if (DateTimeOffset.TryParseExact(expr, "yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture,
@@ -137,7 +138,7 @@ namespace WikiClientLibrary.Infrastructures
                 }
                 if (objectType == typeof(DateTime))
                 {
-                    if (infinityValues.Contains(expr.ToLower()))
+                    if (infinityValues.Contains(expr.ToLowerInvariant()))
                         return DateTime.MaxValue;
                     if (DateTime.TryParseExact(expr, "yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture,
                         DateTimeStyles.RoundtripKind, out var result))


### PR DESCRIPTION
Fixes #50.

I’ve added the tests for all current values for a good measure, if it’s not needed, I guess it could be dropped. I couldn’t run the project in my VS, so this is checked only with Intellisense.