### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/WikiClientLibrary.Flow/WikiClientLibrary.Flow.csproj
+++ b/WikiClientLibrary.Flow/WikiClientLibrary.Flow.csproj
@@ -8,7 +8,15 @@
       WikiClientLibrary.Flow is a .NET Standard &amp; asynchronous client library for MediaWiki sites with Structured Discussions (aka. Flow) support.
     </Description>
     <PackageTags>$(PackageTags) Flow StructuredDiscussions</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\WikiClientLibrary\WikiClientLibrary.csproj" />

--- a/WikiClientLibrary.Wikia/WikiClientLibrary.Wikia.csproj
+++ b/WikiClientLibrary.Wikia/WikiClientLibrary.Wikia.csproj
@@ -9,7 +9,15 @@
       which are using a customized MediaWiki branch based on MediaWiki 1.19.
     </Description>
     <PackageTags>$(PackageTags) Wikia FANDOM</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.6.2" />

--- a/WikiClientLibrary.Wikibase/WikiClientLibrary.Wikibase.csproj
+++ b/WikiClientLibrary.Wikibase/WikiClientLibrary.Wikibase.csproj
@@ -9,7 +9,15 @@
       It also contains API for working with Wikibase offline JSON dump.
     </Description>
     <PackageTags>$(PackageTags) Wikibase Wikidata WikibaseDump</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <ProjectReference Include="..\WikiClientLibrary\WikiClientLibrary.csproj" />

--- a/WikiClientLibrary/WikiClientLibrary.csproj
+++ b/WikiClientLibrary/WikiClientLibrary.csproj
@@ -19,7 +19,15 @@
       * Other miscellaneous MediaWiki API, such as OpenSearch, Page parsing, and Patrol.
       * Scribunto Lua console and server-side module execution support
     </Description>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="CXuesong.AsyncEnumerableExtensions" Version="0.2.0" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
