### PR TITLE
Improve error message for wrong snak dataValue type

### DIFF
--- a/WikiClientLibrary.Wikibase/DataTypes/WikibaseDataType.cs
+++ b/WikiClientLibrary.Wikibase/DataTypes/WikibaseDataType.cs
@@ -100,7 +100,7 @@ namespace WikiClientLibrary.Wikibase.DataTypes
             if (value == null) return null;
             if (value is T t)
                 return toJsonHandler(t);
-            throw new ArgumentException("Value type is incompatible.", nameof(value));
+            throw new ArgumentException($"Value type is incompatible for {Name}: expected {typeof(T)}, received {value.GetType()}.", nameof(value));
         }
 
     }


### PR DESCRIPTION
A mistake in dataValue type might be difficult to find, so let’s report more details in the exception.