### PR TITLE
FilesGenerator

### DIFF
--- a/UnitTestProject1/Tests/GeneratorTests2.cs
+++ b/UnitTestProject1/Tests/GeneratorTests2.cs
@@ -299,6 +299,20 @@ namespace WikiClientLibrary.Tests.UnitTestProject1.Tests
         }
 
         [Fact]
+        public async Task WpEnEnumPageFilesTest()
+        {
+            var site = await WpEnSiteAsync;
+            var gen = new FilesGenerator(site, site.SiteInfo.MainPage) { PaginationSize = 20 };
+            var files = await gen.EnumPagesAsync().Select(p => p.Title).ToListAsync();
+            ShallowTrace(files);
+            Utility.AssertNotNull(files);
+            Assert.Contains("File:Wikidata-logo.svg", files);
+            Assert.Contains("File:Wikibooks-logo.svg", files);
+            Assert.Contains("File:Commons-logo.svg", files);
+            Assert.Contains("File:Wikisource-logo.svg", files);
+        }
+
+        [Fact]
         public async Task WpEnGeoSearchTest1()
         {
             var site = await WpEnSiteAsync;

--- a/WikiClientLibrary/Generators/FilesGenerator.cs
+++ b/WikiClientLibrary/Generators/FilesGenerator.cs
@@ -26,10 +26,10 @@ namespace WikiClientLibrary.Generators
         }
 
         /// <summary>
-        /// Only list links to these titles. Useful for checking whether a certain page links to a certain title.
+        /// Only list these files. Useful for checking whether a certain page has a certain file.
         /// (MediaWiki 1.17+)
         /// </summary>
-        /// <value>a sequence of page titles, or <c>null</c> to list all the linked pages.</value>
+        /// <value>a sequence of page titles, or <c>null</c> to list all the used files.</value>
         public IEnumerable<string>? MatchingTitles { get; set; }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace WikiClientLibrary.Generators
             return new Dictionary<string, object?>
             {
                 {"imlimit", PaginationSize}, 
-                {"imtitles", MatchingTitles == null ? null : MediaWikiHelper.JoinValues(MatchingTitles)},
+                {"imimages", MatchingTitles == null ? null : MediaWikiHelper.JoinValues(MatchingTitles)},
                 {"imdir", OrderDescending ? "descending" : "ascending"}
             };
         }

--- a/WikiClientLibrary/Generators/FilesGenerator.cs
+++ b/WikiClientLibrary/Generators/FilesGenerator.cs
@@ -7,29 +7,23 @@ using WikiClientLibrary.Sites;
 namespace WikiClientLibrary.Generators
 {
     /// <summary>
-    /// Generates pages from all links on the provided page.
+    /// Generates pages from all used files on the provided page.
     /// (<a href="https://www.mediawiki.org/wiki/API:Links">mw:API:Links</a>, MediaWiki 1.11+)
     /// </summary>
     /// <see cref="TransclusionsGenerator"/>
     /// <see cref="BacklinksGenerator"/>
-    /// <see cref="FilesGenerator"/>
-    public class LinksGenerator : WikiPagePropertyGenerator
+    /// <see cref="LinksGenerator"/>
+    public class FilesGenerator : WikiPagePropertyGenerator
     {
         /// <inheritdoc />
-        public LinksGenerator(WikiSite site) : base(site)
+        public FilesGenerator(WikiSite site) : base(site)
         {
         }
 
         /// <inheritdoc />
-        public LinksGenerator(WikiSite site, WikiPageStub pageStub) : base(site, pageStub)
+        public FilesGenerator(WikiSite site, WikiPageStub pageStub) : base(site, pageStub)
         {
         }
-
-        /// <summary>
-        /// Only list pages in these namespaces.
-        /// </summary>
-        /// <value>selected IDs of namespace, or <c>null</c> to select all the namespaces.</value>
-        public IEnumerable<int>? NamespaceIds { get; set; }
 
         /// <summary>
         /// Only list links to these titles. Useful for checking whether a certain page links to a certain title.
@@ -45,17 +39,16 @@ namespace WikiClientLibrary.Generators
         public bool OrderDescending { get; set; }
 
         /// <inheritdoc />
-        public override string PropertyName => "links";
+        public override string PropertyName => "images";
 
         /// <inheritdoc />
         public override IEnumerable<KeyValuePair<string, object?>> EnumListParameters()
         {
             return new Dictionary<string, object?>
             {
-                {"plnamespace", NamespaceIds == null ? null : MediaWikiHelper.JoinValues(NamespaceIds)},
-                {"pllimit", PaginationSize},
-                {"pltitles", MatchingTitles == null ? null : MediaWikiHelper.JoinValues(MatchingTitles)},
-                {"pldir", OrderDescending ? "descending" : "ascending"}
+                {"imlimit", PaginationSize}, 
+                {"imtitles", MatchingTitles == null ? null : MediaWikiHelper.JoinValues(MatchingTitles)},
+                {"imdir", OrderDescending ? "descending" : "ascending"}
             };
         }
     }

--- a/WikiClientLibrary/Generators/WikiPageExtensions.cs
+++ b/WikiClientLibrary/Generators/WikiPageExtensions.cs
@@ -21,6 +21,17 @@ namespace WikiClientLibrary.Generators
             if (page == null) throw new ArgumentNullException(nameof(page));
             return new LinksGenerator(page.Site, page.PageStub);
         }
+        
+        /// <summary>
+        /// Creates a <see cref="FilesGenerator"/> instance from the specified page,
+        /// which generates files from all used files on the page.
+        /// </summary>
+        /// <param name="page">The page.</param>
+        public static FilesGenerator CreateFilesGenerator(this WikiPage page)
+        {
+            if (page == null) throw new ArgumentNullException(nameof(page));
+            return new FilesGenerator(page.Site, page.PageStub);
+        }
 
         /// <summary>
         /// Creates a <see cref="TransclusionsGenerator"/> instance from the specified page,


### PR DESCRIPTION
A new generator similar to LinkGenerator but for files ([example](https://en.wikipedia.org/w/api.php?action=query&format=json&prop=images&titles=.NET&formatversion=2)). List generators returns files only of they are used as a link, like [[:File:Image.svg]], not when the files is used as a file like [[File:Image.svg]].