### PR TITLE
Add MyWatchlistGenerator

### DIFF
--- a/WikiClientLibrary/Generators/MyWatchlistGenerator.cs
+++ b/WikiClientLibrary/Generators/MyWatchlistGenerator.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using WikiClientLibrary.Generators.Primitive;
+using WikiClientLibrary.Infrastructures;
+using WikiClientLibrary.Sites;
+
+namespace WikiClientLibrary.Generators
+{
+    /// <summary>
+    /// Get all pages on the current user's watchlist.
+    /// </summary>
+    public class MyWatchlistGenerator : WikiPageGenerator
+    {
+        public MyWatchlistGenerator(WikiSite site) : base(site)
+        {
+        }
+
+        /// <summary>
+        /// Only list pages in the given namespaces.
+        /// </summary>
+        public IEnumerable<int>? NamespaceIds { get; set; }
+
+        /// <summary>
+        /// Adds timestamp of when the user was last notified about the edit.
+        /// </summary>
+        public bool ShowChangedTime { get; set; }
+
+        /// <summary>
+        /// Only show pages that have not been changed.
+        /// </summary>
+        public PropertyFilterOption NotChangedPagesFilter { get; set; }
+
+        /// <summary>
+        /// Gets/sets a value that indicates whether the links should be listed in
+        /// the descending order. (MediaWiki 1.19+)
+        /// </summary>
+        public bool OrderDescending { get; set; }
+
+        /// <summary>
+        /// Title (with namespace prefix) to begin enumerating from.
+        /// </summary>
+        public string? FromTitle { get; set; }
+
+        /// <summary>
+        /// Title (with namespace prefix) to stop enumerating at.
+        /// </summary>
+        public string? ToTitle { get; set; }
+
+        public override IEnumerable<KeyValuePair<string, object?>> EnumListParameters()
+        {
+            return new Dictionary<string, object?>
+            {
+                {"wrnamespace", NamespaceIds == null ? null : MediaWikiHelper.JoinValues(NamespaceIds)},
+                {"wrlimit", PaginationSize},
+                {"wrprop", ShowChangedTime ? "changed" : null},
+                {"wrshow", NotChangedPagesFilter.ToString("!changed", "changed", null)},
+                {"wrdir", OrderDescending ? "descending" : "ascending"},
+                {"wrfromtitle", FromTitle},
+                {"wrtotitle", ToTitle},
+            };
+        }
+
+        public override string ListName => "watchlistraw";
+    }
+}


### PR DESCRIPTION
A new page generator to get pages from logged-in user's watchlist. 

I'm not quite sure if the generator is within the scope of this project but I had to [create it for my project](https://github.com/ashotjanibekyan/CrossWikiEditor/blob/f3c063dc48ce5e21bcbee15cf95a6f6b879bda31/CrossWikiEditor/WikiClientLibraryUtils/Generators/MyWatchlistGenerator.cs) and thought it could be useful here too.