### PR TITLE
Add PagesWithPropGenerator

### DIFF
--- a/UnitTestProject1/Tests/GeneratorTests2.cs
+++ b/UnitTestProject1/Tests/GeneratorTests2.cs
@@ -408,5 +408,16 @@ namespace WikiClientLibrary.Tests.UnitTestProject1.Tests
                 new HashSet<string>(pages.Select(p => p.Title!)));
         }
 
+        [Fact]
+        public async Task WpEnPageWithPropTest()
+        {
+            var site = await WpEnSiteAsync;
+            var generator = new PagesWithPropGenerator(site, "defaultsort");
+            var result = await generator.EnumItemsAsync().Take(10).ToListAsync();
+            var pages = await generator.EnumPagesAsync().Take(10).ToListAsync();
+            Utility.AssertTitlesDistinct(pages);
+            Assert.All(result, r => Assert.NotNull(r.Value));
+        }
+
     }
 }

--- a/WikiClientLibrary/Generators/PagesWithPropGenerator.cs
+++ b/WikiClientLibrary/Generators/PagesWithPropGenerator.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using WikiClientLibrary.Generators.Primitive;
+using WikiClientLibrary.Infrastructures;
+using WikiClientLibrary.Sites;
+
+namespace WikiClientLibrary.Generators
+{
+    /// <summary>
+    /// List all pages using a given page property. The list of available properties can be found at action=query&amp;list=pagepropnames.
+    /// </summary>
+    public class PagesWithPropGenerator : WikiPageGenerator<PagesWithPropResultItem>
+    {
+        public PagesWithPropGenerator(WikiSite site, string propertyName) : base(site)
+        {
+            PropertyName = propertyName;
+        }
+
+        /// <summary>
+        /// Page property for which to enumerate pages (action=query&list=pagepropnames returns page property names in use).
+        /// </summary>
+        public string PropertyName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets/sets a value that indicates whether the links should be listed in
+        /// the descending order. (MediaWiki 1.19+)
+        /// </summary>
+        public bool OrderDescending { get; set; }
+    
+        public override string ListName => "pageswithprop";
+
+        public override IEnumerable<KeyValuePair<string, object?>> EnumListParameters()
+        {
+            return new Dictionary<string, object?>
+            {
+                {"pwpprop", "ids|title|value"},
+                {"pwppropname", PropertyName},
+                {"pwplimit", PaginationSize},
+                {"pwpdir", OrderDescending ? "descending" : "ascending"},
+            };
+        }
+
+        protected override PagesWithPropResultItem ItemFromJson(JToken json)
+        {
+            return new PagesWithPropResultItem(MediaWikiHelper.PageStubFromJson((JObject)json), (string)json["value"]);
+        }
+    }
+}

--- a/WikiClientLibrary/Generators/PagesWithPropResultItem.cs
+++ b/WikiClientLibrary/Generators/PagesWithPropResultItem.cs
@@ -1,0 +1,16 @@
+﻿using WikiClientLibrary.Pages;
+
+namespace WikiClientLibrary.Generators
+{
+    public class PagesWithPropResultItem
+    {
+        public WikiPageStub Page { get; }
+        public string Value { get; set; }
+
+        public PagesWithPropResultItem(WikiPageStub wikiPageStub, string value)
+        {
+            Page = wikiPageStub;
+            Value = value;
+        }
+    }
+}


### PR DESCRIPTION
A new page generator for _action=query&list=pageswithprop_, [example](https://hy.wikipedia.org/w/api.php?action=query&format=json&list=pageswithprop&formatversion=2&pwppropname=defaultsort&pwpprop=ids%7Ctitle%7Cvalue).