### PR TITLE
Include ByteOffset for deserialization in ContentSectionInfo

### DIFF
--- a/WikiClientLibrary/Pages/Parsing/ParsedContentInfo.cs
+++ b/WikiClientLibrary/Pages/Parsing/ParsedContentInfo.cs
@@ -194,6 +194,7 @@ namespace WikiClientLibrary.Pages.Parsing
         /// Note that sometimes this property is not available,
         /// especially when the heading is included in a template.
         /// </remarks>
+        [JsonProperty]
         public int? ByteOffset { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
When requesting sections, it may not return a value for the property but if it does the `[JsonObject(MemberSerialization.OptIn)]` will exclude it all the same so you always get `null`.  

This will opt the member in for serialization.
