### PR TITLE
Revision IDs need to be long everywhere

### DIFF
--- a/WikiClientLibrary.Wikibase/Entity.Editing.cs
+++ b/WikiClientLibrary.Wikibase/Entity.Editing.cs
@@ -208,7 +208,7 @@ partial class Entity
                             token = WikiSiteToken.Edit,
                             id = Id,
                             @new = Id == null ? FormatEntityType(Type) : null,
-                            baserevid = LastRevisionId > 0 ? (int?)LastRevisionId : null,
+                            baserevid = LastRevisionId > 0 ? (long?)LastRevisionId : null,
                             bot = (options & EntityEditOptions.Bot) == EntityEditOptions.Bot,
                             summary = summary,
                             clear = (options & EntityEditOptions.ClearData) == EntityEditOptions.ClearData,
@@ -258,7 +258,7 @@ partial class Entity
                             token = WikiSiteToken.Edit,
                             id = Id,
                             @new = Id == null ? FormatEntityType(Type) : null,
-                            baserevid = checkbaseRev && LastRevisionId > 0 ? (int?)LastRevisionId : null,
+                            baserevid = checkbaseRev && LastRevisionId > 0 ? (long?)LastRevisionId : null,
                             bot = isBot,
                             summary = summary,
                             language = value.Language,
@@ -279,7 +279,7 @@ partial class Entity
                             token = WikiSiteToken.Edit,
                             id = Id,
                             @new = Id == null ? FormatEntityType(Type) : null,
-                            baserevid = checkbaseRev && LastRevisionId > 0 ? (int?)LastRevisionId : null,
+                            baserevid = checkbaseRev && LastRevisionId > 0 ? (long?)LastRevisionId : null,
                             bot = isBot,
                             summary = summary,
                             language = value.Language,
@@ -306,7 +306,7 @@ partial class Entity
                                 token = WikiSiteToken.Edit,
                                 id = Id,
                                 @new = Id == null ? FormatEntityType(Type) : null,
-                                baserevid = checkbaseRev && LastRevisionId > 0 ? (int?)LastRevisionId : null,
+                                baserevid = checkbaseRev && LastRevisionId > 0 ? (long?)LastRevisionId : null,
                                 bot = isBot,
                                 summary = summary,
                                 language = langGroup.Key,
@@ -344,7 +344,7 @@ partial class Entity
                                 token = WikiSiteToken.Edit,
                                 id = Id,
                                 @new = Id == null ? FormatEntityType(Type) : null,
-                                baserevid = checkbaseRev && LastRevisionId > 0 ? (int?)LastRevisionId : null,
+                                baserevid = checkbaseRev && LastRevisionId > 0 ? (long?)LastRevisionId : null,
                                 bot = isBot,
                                 summary = summary,
                                 linksite = siteGroup.Key,
@@ -389,13 +389,13 @@ partial class Entity
                             action = "wbsetclaim",
                             token = WikiSiteToken.Edit,
                             @new = Id == null ? FormatEntityType(Type) : null,
-                            baserevid = checkbaseRev && LastRevisionId > 0 ? (int?)LastRevisionId : null,
+                            baserevid = checkbaseRev && LastRevisionId > 0 ? (long?)LastRevisionId : null,
                             bot = isBot,
                             summary = summary,
                             claim = Utility.WikiJsonSerializer.Serialize(claimContract),
                         }), cancellationToken);
                         // jresult["claim"] != null
-                        LastRevisionId = (int)jresult["pageinfo"]["lastrevid"];
+                        LastRevisionId = (long)jresult["pageinfo"]["lastrevid"];
                         if (!strict) checkbaseRev = false;
                     }
                     foreach (var batch in prop.Where(e => e.State == EntityEditEntryState.Removed)
@@ -407,12 +407,12 @@ partial class Entity
                             token = WikiSiteToken.Edit,
                             id = Id,
                             @new = Id == null ? FormatEntityType(Type) : null,
-                            baserevid = checkbaseRev && LastRevisionId > 0 ? (int?)LastRevisionId : null,
+                            baserevid = checkbaseRev && LastRevisionId > 0 ? (long?)LastRevisionId : null,
                             bot = isBot,
                             summary = summary,
                             claim = MediaWikiHelper.JoinValues(batch),
                         }), cancellationToken);
-                        LastRevisionId = (int)jresult["pageinfo"]["lastrevid"];
+                        LastRevisionId = (long)jresult["pageinfo"]["lastrevid"];
                         if (!strict) checkbaseRev = false;
                     }
                     break;
@@ -426,7 +426,7 @@ partial class Entity
             Debug.Assert(jentity != null);
             Id = (string)jentity["id"];
             Type = SerializableEntity.ParseEntityType((string)jentity["type"]);
-            LastRevisionId = (int)jentity["lastrevid"];
+            LastRevisionId = (long)jentity["lastrevid"];
         }
     }
 

--- a/WikiClientLibrary/Generators/BacklinksGenerator.cs
+++ b/WikiClientLibrary/Generators/BacklinksGenerator.cs
@@ -31,7 +31,7 @@ public class BacklinksGenerator : WikiPageGenerator
     /// <summary>
     /// List pages linking to this page ID.
     /// </summary>
-    public int? TargetPageId { get; set; }
+    public long? TargetPageId { get; set; }
 
     /// <summary>
     /// Only list pages in these namespaces.

--- a/WikiClientLibrary/Generators/Primitive/WikiPageGenerator.cs
+++ b/WikiClientLibrary/Generators/Primitive/WikiPageGenerator.cs
@@ -137,7 +137,7 @@ public abstract class WikiPageGenerator : WikiPageGenerator<WikiPageStub>
     /// <inheritdoc />
     protected override WikiPageStub ItemFromJson(JToken json)
     {
-        return new WikiPageStub((int)json["pageid"], (string)json["title"], (int)json["ns"]);
+        return new WikiPageStub((long)json["pageid"], (string)json["title"], (int)json["ns"]);
     }
 
 }

--- a/WikiClientLibrary/Generators/Primitive/WikiPagePropertyGenerator.cs
+++ b/WikiClientLibrary/Generators/Primitive/WikiPagePropertyGenerator.cs
@@ -119,7 +119,7 @@ public abstract class WikiPagePropertyGenerator : WikiPagePropertyGenerator<Wiki
     protected override WikiPageStub ItemFromJson(JToken json, JObject jpage)
     {
         // pageid can be missing in this case.
-        return new WikiPageStub((int?)json["pageid"] ?? 0, (string)json["title"], (int)json["ns"]);
+        return new WikiPageStub((long?)json["pageid"] ?? 0, (string)json["title"], (int)json["ns"]);
     }
 
 }

--- a/WikiClientLibrary/Generators/RandomPageGenerator.cs
+++ b/WikiClientLibrary/Generators/RandomPageGenerator.cs
@@ -27,7 +27,7 @@ public class RandomPageGenerator : WikiPageGenerator
     protected override WikiPageStub ItemFromJson(JToken json)
     {
         // Note: page ID is contained in ["id"] rather than ["pageid"].
-        return new WikiPageStub((int)json["id"], (string)json["title"], (int)json["ns"]);
+        return new WikiPageStub((long)json["id"], (string)json["title"], (int)json["ns"]);
     }
 
     /// <summary>

--- a/WikiClientLibrary/Infrastructures/MediaWikiHelper.cs
+++ b/WikiClientLibrary/Infrastructures/MediaWikiHelper.cs
@@ -186,14 +186,14 @@ public static class MediaWikiHelper
             if (jPage["title"] != null)
                 return WikiPageStub.NewMissingPage((string)jPage["title"], (int)jPage["ns"]);
             if (jPage["pageid"] != null)
-                return WikiPageStub.NewMissingPage((int)jPage["pageid"]);
+                return WikiPageStub.NewMissingPage((long)jPage["pageid"]);
             return WikiPageStub.NewMissingPage(WikiPageStub.MissingPageIdMask);
         }
         if (jPage["pageid"] != null)
         {
             if (jPage["title"] != null)
-                return new WikiPageStub((int)jPage["pageid"], (string)jPage["title"], (int)jPage["ns"]);
-            return new WikiPageStub((int)jPage["pageid"]);
+                return new WikiPageStub((long)jPage["pageid"], (string)jPage["title"], (int)jPage["ns"]);
+            return new WikiPageStub((long)jPage["pageid"]);
         }
         if (jPage["title"] != null)
             return new WikiPageStub((string)jPage["title"], (int)jPage["ns"]);

--- a/WikiClientLibrary/Pages/Parsing/WikiSiteExtensions.cs
+++ b/WikiClientLibrary/Pages/Parsing/WikiSiteExtensions.cs
@@ -131,20 +131,20 @@ public static class WikiSiteExtensions
         return parsed;
     }
 
-    /// <inheritdoc cref="ParseRevisionAsync(WikiSite,int,string,ParsingOptions,CancellationToken)"/>
-    public static Task<ParsedContentInfo> ParseRevisionAsync(this WikiSite site, int revId)
+    /// <inheritdoc cref="ParseRevisionAsync(WikiSite,long,string,ParsingOptions,CancellationToken)"/>
+    public static Task<ParsedContentInfo> ParseRevisionAsync(this WikiSite site, long revId)
     {
         return ParseRevisionAsync(site, revId, null, ParsingOptions.None, CancellationToken.None);
     }
 
-    /// <inheritdoc cref="ParseRevisionAsync(WikiSite,int,string,ParsingOptions,CancellationToken)"/>
-    public static Task<ParsedContentInfo> ParseRevisionAsync(this WikiSite site, int revId, ParsingOptions options)
+    /// <inheritdoc cref="ParseRevisionAsync(WikiSite,long,string,ParsingOptions,CancellationToken)"/>
+    public static Task<ParsedContentInfo> ParseRevisionAsync(this WikiSite site, long revId, ParsingOptions options)
     {
         return ParseRevisionAsync(site, revId, null, options, CancellationToken.None);
     }
 
-    /// <inheritdoc cref="ParseRevisionAsync(WikiSite,int,string,ParsingOptions,CancellationToken)"/>
-    public static Task<ParsedContentInfo> ParseRevisionAsync(this WikiSite site, int revId, ParsingOptions options,
+    /// <inheritdoc cref="ParseRevisionAsync(WikiSite,long,string,ParsingOptions,CancellationToken)"/>
+    public static Task<ParsedContentInfo> ParseRevisionAsync(this WikiSite site, long revId, ParsingOptions options,
         CancellationToken cancellationToken)
     {
         return ParseRevisionAsync(site, revId, null, options, CancellationToken.None);
@@ -159,7 +159,7 @@ public static class WikiSiteExtensions
     /// <param name="options">Options for parsing.</param>
     /// <param name="cancellationToken">The cancellation token that will be checked prior to completing the returned task.</param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="revId"/> is zero or negative.</exception>
-    public static async Task<ParsedContentInfo> ParseRevisionAsync(this WikiSite site, int revId, string? lang, ParsingOptions options,
+    public static async Task<ParsedContentInfo> ParseRevisionAsync(this WikiSite site, long revId, string? lang, ParsingOptions options,
         CancellationToken cancellationToken)
     {
         if (site == null) throw new ArgumentNullException(nameof(site));

--- a/WikiClientLibrary/Pages/Queries/Properties/PageInfoPropertyProvider.cs
+++ b/WikiClientLibrary/Pages/Queries/Properties/PageInfoPropertyProvider.cs
@@ -47,7 +47,7 @@ public class PageInfoPropertyGroup : WikiPagePropertyGroup
         else
         {
             ContentLength = (int)jPage["length"];
-            LastRevisionId = (int)jPage["lastrevid"];
+            LastRevisionId = (long)jPage["lastrevid"];
             LastTouched = (DateTime)jPage["touched"];
             if (jPage["protection"] != null && jPage["protection"].HasValues)
                 Protections = jPage["protection"].ToObject<IReadOnlyCollection<ProtectionInfo>>(Utility.WikiJsonSerializer);

--- a/WikiClientLibrary/Pages/WikiPage.cs
+++ b/WikiClientLibrary/Pages/WikiPage.cs
@@ -475,11 +475,11 @@ public partial class WikiPage
                     return false;
                 }
                 ContentModel = (string)jedit["contentmodel"];
-                LastRevisionId = (int)jedit["newrevid"];
+                LastRevisionId = (long)jedit["newrevid"];
                 LastRevision = null;
                 pageInfo = null;
                 // jedit["ns"] == null
-                PageStub = new WikiPageStub((int)jedit["pageid"], (string)jedit["title"], PageStub.NamespaceId);
+                PageStub = new WikiPageStub((long)jedit["pageid"], (string)jedit["title"], PageStub.NamespaceId);
                 Site.Logger.LogInformation("Edited page. New revid={RevisionId}.", LastRevisionId);
                 return true;
             }

--- a/WikiClientLibrary/Pages/WikiPageStub.cs
+++ b/WikiClientLibrary/Pages/WikiPageStub.cs
@@ -277,7 +277,7 @@ public readonly struct WikiPageStub : IEquatable<WikiPageStub>
                     normalizedName = name;
                 var jpage = pageDict[normalizedName];
                 if (jpage["missing"] == null)
-                    yield return (new WikiPageStub((int)jpage["pageid"], (string)jpage["title"], (int)jpage["ns"]));
+                    yield return (new WikiPageStub((long)jpage["pageid"], (string)jpage["title"], (int)jpage["ns"]));
                 else
                     yield return (new WikiPageStub(MissingPageIdMask, (string)jpage["title"], (int)jpage["ns"]));
             }


### PR DESCRIPTION
In df21c73a5636676cff99eeb2a1c7a1e2218f88bf, revision IDs have been changed to 64-bit longs, which is now necessary on Wikidata. However, wrong explicit `(int)` casts remained in the code at multiple places, causing exceptions.

Fixes #112