### PR TITLE
Update CI build properties and adjust package settings for better debugging integration

### DIFF
--- a/WikiClientLibrary.Commons/WikiClientLibrary.Commons.props
+++ b/WikiClientLibrary.Commons/WikiClientLibrary.Commons.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(WCL_IS_CI_BUILD)' == '1' Or '$(WCL_IS_CI_BUILD)' == 'True' Or '$(WCL_IS_CI_BUILD)' == 'On' Or '$(WCL_IS_CI_BUILD)' == 'Yes' ">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <DefineConstants>$(DefineConstants);ENV_CI_BUILD</DefineConstants>
     <!-- Normalize value -->
     <WCL_IS_CI_BUILD>True</WCL_IS_CI_BUILD>

--- a/WikiClientLibrary.Commons/WikiClientLibrary.Packages.props
+++ b/WikiClientLibrary.Commons/WikiClientLibrary.Packages.props
@@ -23,7 +23,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\WikiClientLibrary.snk</AssemblyOriginatorKeyFile>
     <PublishRepositoryUrl>True</PublishRepositoryUrl>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since the packages are built with source link, for a better debugging experience you should either upload the symbol packages to NuGet or distribute the PDBs alongside the application (which you do). 



But a user needs to set `CopyDebugSymbolFilesFromPackages` to true in their build properties.  

Changing the PDBs to be embedded will allow debuggers to easily discover them when users want to step into the source.



This PR also enables reproduceable builds by setting the `ContinuousIntegrationBuild` to true during CI.

