### PR TITLE
When removing aliases, the old value needs to be sent to the API

### DIFF
--- a/WikiClientLibrary.Wikibase/Entity.Editing.cs
+++ b/WikiClientLibrary.Wikibase/Entity.Editing.cs
@@ -60,7 +60,7 @@ partial class Entity
                         Debug.Assert(entry.Value != null);
                         var value = (WbMonolingualText)entry.Value;
                         var item = entry.State == EntityEditEntryState.Removed
-                            ? new Contracts.MonolingualText { Language = value.Language, Remove = true }
+                            ? new Contracts.MonolingualText { Language = value.Language, Value = value.Text, Remove = true }
                             : new Contracts.MonolingualText { Language = value.Language, Value = value.Text };
                         if (!contract.Aliases.TryGetValue(item.Language, out var items))
                         {


### PR DESCRIPTION
While for `Labels` and `Descriptions` this is fine (those are `WbMonolingualTextCollection` – the language uniquely identifies the label/description to be removed), for `Aliases` this does not work: it is a `WbMonolingualTextsCollection`, and the language identifies a set of aliases, and the specific alias to be removed needs to be specified.

Fixes #123